### PR TITLE
move gw2 api key to query param instead of auth header

### DIFF
--- a/server/src/services/gw2/gw2-api.ts
+++ b/server/src/services/gw2/gw2-api.ts
@@ -13,8 +13,8 @@ export class GW2Api {
 
   async get<T>(endpoint: string): Promise<T> {
     const response = await axios.get(endpoint, {
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`
+      params: {
+        access_token: this.apiKey
       },
       baseURL: this.baseUrl
     });


### PR DESCRIPTION
this is to workaround an issue with the gw2 api