### PR TITLE
Normalize discord names

### DIFF
--- a/client/src/lib/utils/data-processing.ts
+++ b/client/src/lib/utils/data-processing.ts
@@ -28,7 +28,8 @@ export const generateGW2RosterRecords = (
         }
 
         const discordName = m.name
-          ?.toLowerCase()
+          ?.normalize('NFKC')
+          .toLowerCase()
           .replace(
             /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
             ''


### PR DESCRIPTION
Converts "funky" characters to regular characters that are more likely to be in the GW2 name, e.g. 𝕸 -> M