### PR TITLE
overhaul to authorising various actions for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,30 @@ Uses Discord and GW2 API to help manage a Guild and Discord server, keep them in
 
 To run this you do need to set up the following env variables:
 
-| value                           | description                                                                                                               |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **PORT**                        | Port to run Express server on                                                                                             |
-| **DATABASE_URI**                | Postgres Database URI                                                                                                     |
-| **SESSION_SECRET**              | Secret for Express Session                                                                                                |
-| **ACCESS_TOKEN_ENCRYPTION_KEY** | Key for encrypting access token                                                                                           |
-| BOT_TOKEN                       | (Optional, mock services used if ommitted) Discord bot access token from the Guild's discord server                       |
-| GW2_GUILD_ID                    | (Optional, mock services used if ommitted) ID of Guild Wars 2 guild                                                       |
-| GW2_API_TOKEN                   | (Optional, mock services used if ommitted) Guild Wars 2 API Token                                                         |
-| DISCORD_GUILD_ID                | (Optional, mock services used if ommitted) ID of Guild's discord server                                                   |
-| DISCORD_CLIENT_ID               | (Optional if skipping auth) Client ID for Discord OAuth                                                                   |
-| DISCORD_CLIENT_SECRET           | (Optional if skipping auth) Client Secret for Discord OAuth                                                               |
-| DISCORD_AUTH_REDIRECT           | (Optional if skipping auth) OAuth Redirect URL                                                                            |
-| ADMIN_ROLES                     | (Optional if skipping auth) Comma Seperated List of Admin Discord Roles                                                   |
-| EVENT_ROLES                     | (Optional if skipping auth) Comma Seperated List of Event Leaders (all Admins will also be included so no need to repeat) |
-| **_SKIP_AUTH_**                 | (Optional) Enable to skip auth during dev (required if using mock services)                                               |
-| FRONT_END_BASE_URL              | (Optional) Frontend URL for backend to point to (useful with React dev server)                                            |
-| EVENT_UPDATE_INTERVAL_HOURS     | (Optional) Interval for updating event posts, defaults to 6 hours                                                         |
-| VITE_APP_BACKEND_BASE_URL       | (Optional) Backend URL for React to point to (useful with React dev server)                                               |
-| VITE_DISCORD_REINVITE_LINK      | (Optional) Invite link to send to kicked users                                                                            |
+| value                           | description                                                                                         |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **PORT**                        | Port to run Express server on                                                                       |
+| **DATABASE_URI**                | Postgres Database URI                                                                               |
+| **SESSION_SECRET**              | Secret for Express Session                                                                          |
+| **ACCESS_TOKEN_ENCRYPTION_KEY** | Key for encrypting access token                                                                     |
+| BOT_TOKEN                       | (Optional, mock services used if ommitted) Discord bot access token from the Guild's discord server |
+| GW2_GUILD_ID                    | (Optional, mock services used if ommitted) ID of Guild Wars 2 guild                                 |
+| GW2_API_TOKEN                   | (Optional, mock services used if ommitted) Guild Wars 2 API Token                                   |
+| DISCORD_GUILD_ID                | (Optional, mock services used if ommitted) ID of Guild's discord server                             |
+| DISCORD_CLIENT_ID               | (Optional if skipping auth) Client ID for Discord OAuth                                             |
+| DISCORD_CLIENT_SECRET           | (Optional if skipping auth) Client Secret for Discord OAuth                                         |
+| DISCORD_AUTH_REDIRECT           | (Optional if skipping auth) OAuth Redirect URL                                                      |
+| AUTH_ACCESS                     | Comma Seperated List of Admin Discord Roles                                                         |
+| AUTH_MANAGE_EVENTS              | Roles who can manage events                                                                         |
+| AUTH_MANAGE_WARNINGS            | Roles who can manage warnings                                                                       |
+| AUTH_MANAGE_MEMBERS             | Roles who can manage members                                                                        |
+| AUTH_MANAGE_RECRUITMENT         | Roles who can manage recruitment                                                                    |
+| EVENT_ROLES                     | Comma Seperated List of Event Leaders                                                               |
+| **_SKIP_AUTH_**                 | (Optional) Enable to skip auth during dev (required if using mock services)                         |
+| FRONT_END_BASE_URL              | (Optional) Frontend URL for backend to point to (useful with React dev server)                      |
+| EVENT_UPDATE_INTERVAL_HOURS     | (Optional) Interval for updating event posts, defaults to 6 hours                                   |
+| VITE_APP_BACKEND_BASE_URL       | (Optional) Backend URL for React to point to (useful with React dev server)                         |
+| VITE_DISCORD_REINVITE_LINK      | (Optional) Invite link to send to kicked users                                                      |
 
 ## Available Scripts
 

--- a/client/src/components/app.tsx
+++ b/client/src/components/app.tsx
@@ -15,11 +15,11 @@ import Roster from './roster/roster';
 const App = () => {
   const { data: authInfo } = useAuth();
 
-  usePrefetchGW2Log(!!authInfo && !!authInfo.loggedIn);
+  usePrefetchGW2Log(!!authInfo && !!authInfo.permissions.ACCESS);
 
   return (
     <Box className="paper-container">
-      {authInfo && authInfo.loggedIn && authInfo.isAdmin ? (
+      {authInfo && authInfo.loggedIn && authInfo.permissions.ACCESS ? (
         <BrowserRouter>
           <Routes>
             <Route path="/" Component={Layout}>

--- a/client/src/components/events/event-entry.tsx
+++ b/client/src/components/events/event-entry.tsx
@@ -18,7 +18,7 @@ import { type Theme } from '@mui/material/styles/createTheme';
 import equal from 'fast-deep-equal';
 import type React from 'react';
 import { type ComponentProps, useCallback, useMemo, useState } from 'react';
-import { daysOfWeek, type DiscordMemberDTO, type EventCreateDTO } from 'server';
+import { type AuthInfo, daysOfWeek, type DiscordMemberDTO, type EventCreateDTO } from 'server';
 import { useToast } from '../common/toast/toast-context';
 import './event-entry.scss';
 
@@ -36,6 +36,7 @@ interface Props {
   possibleLeaders: DiscordMemberDTO[];
   onDelete?: () => Promise<void>;
   onSubmit: (e: EventCreateDTO) => Promise<void>;
+  authData: AuthInfo;
   resetOnSubmit?: boolean;
   changeOpacityWhenIgnored?: boolean;
 }
@@ -43,6 +44,7 @@ interface Props {
 const EventEntry = ({
   initialData = emptyEvent,
   possibleLeaders,
+  authData,
   onSubmit,
   onDelete,
   resetOnSubmit,
@@ -51,6 +53,8 @@ const EventEntry = ({
   const [localEvent, setLocalEvent] = useState(initialData);
   const modified = useMemo(() => !equal(localEvent, initialData), [localEvent, initialData]);
   const openToast = useToast();
+
+  const hasEditPermission = authData.permissions.EVENTS;
 
   const validationHelper = useCallback((event: EventCreateDTO) => {
     if (!event.title) throw new Error('A title must be provided');
@@ -143,13 +147,24 @@ const EventEntry = ({
         <Tooltip placement="top" title="Event name">
           <div className="field long">
             <Assignment color="secondary" className="field-label" />
-            <EditField onEdit={v => onEdit('title', v)} value={localEvent.title} required />
+            <EditField
+              disabled={!hasEditPermission}
+              onEdit={v => onEdit('title', v)}
+              value={localEvent.title}
+              required
+            />
           </div>
         </Tooltip>
         <Tooltip placement="top" title="Event day">
           <div className="field">
             <CalendarToday color="secondary" className="field-label" />
-            <EditField onEdit={v => onEdit('day', v)} value={localEvent.day} select required>
+            <EditField
+              disabled={!hasEditPermission}
+              onEdit={v => onEdit('day', v)}
+              value={localEvent.day}
+              select
+              required
+            >
               {daysOfWeek.map(day => (
                 <MenuItem value={day} key={day}>
                   {day}
@@ -161,19 +176,29 @@ const EventEntry = ({
         <Tooltip placement="top" title={`Start time (${timezoneString})`}>
           <div className="field">
             <WatchLater color="secondary" className="field-label" />
-            <EditField onEdit={setUtcStartTimeWithLocalTime} value={localStartTime} type="time" />
+            <EditField
+              disabled={!hasEditPermission}
+              onEdit={setUtcStartTimeWithLocalTime}
+              value={localStartTime}
+              type="time"
+            />
           </div>
         </Tooltip>
         <Tooltip placement="top" title="Event duration">
           <div className="field">
             <HourglassFull color="secondary" className="field-label" />
-            <EditField onEdit={v => onEdit('duration', v)} value={localEvent.duration} />
+            <EditField
+              disabled={!hasEditPermission}
+              onEdit={v => onEdit('duration', v)}
+              value={localEvent.duration}
+            />
           </div>
         </Tooltip>
         <Tooltip placement="top" title="Event leader">
           <div className="field long">
             <Person color="secondary" className="field-label" />
             <EditField
+              disabled={!hasEditPermission}
               onEdit={v => onEdit('leaderId', v)}
               value={localEvent.leaderId}
               select
@@ -193,6 +218,7 @@ const EventEntry = ({
               label="Ignored"
               control={
                 <Checkbox
+                  disabled={!hasEditPermission}
                   checked={localEvent.ignore}
                   onChange={e => setLocalEvent({ ...localEvent, ignore: e.target.checked })}
                 />
@@ -209,6 +235,7 @@ const EventEntry = ({
                   color="primary"
                   size="small"
                   className="save"
+                  disabled={!hasEditPermission}
                   type="submit"
                 >
                   Save
@@ -223,7 +250,12 @@ const EventEntry = ({
           ) : null}
           {onDelete && (
             <Tooltip placement="top" title="Delete Event">
-              <IconButton color="error" size="small" onClick={onDelete}>
+              <IconButton
+                disabled={!hasEditPermission}
+                color="error"
+                size="small"
+                onClick={onDelete}
+              >
                 <DeleteForever />
               </IconButton>
             </Tooltip>

--- a/client/src/components/login-page.tsx
+++ b/client/src/components/login-page.tsx
@@ -44,7 +44,7 @@ const LoginPage = () => {
             <DiscordLogo height="24" width="24" className="discord-logo" />
             Log In
           </Button>
-          {authInfo.loggedIn && !authInfo.isAdmin ? (
+          {authInfo.loggedIn && !authInfo.permissions.ACCESS ? (
             <Alert className="warning" severity="warning">
               <AlertTitle>Forbidden</AlertTitle>
               You do not have permission to access this site.

--- a/client/src/components/recruitment/recruitment-page.tsx
+++ b/client/src/components/recruitment/recruitment-page.tsx
@@ -12,10 +12,12 @@ import {
 import LoaderPage from '../common/loader-page';
 import { useToast } from '../common/toast/toast-context';
 
+import { useAuth } from '../../lib/apis/auth-api';
 import './recruitment-page.scss';
 
 const RecruitmentPage: FC = () => {
   const { data, isSuccess, isLoading } = useRecruitmentPost();
+  const { data: authData, isLoading: authLoading } = useAuth();
   const recruitmentPostMutation = useRecruitmentPostMutation();
   const [message, setMessage] = useState('');
   const [title, setTitle] = useState('');
@@ -64,7 +66,7 @@ const RecruitmentPage: FC = () => {
     }
   };
 
-  if (isLoading) {
+  if (isLoading || authLoading || !authData) {
     return <LoaderPage />;
   }
 
@@ -76,14 +78,16 @@ const RecruitmentPage: FC = () => {
     >
       <Box justifyContent="space-between" alignItems="center" display="flex">
         <h2>Recruitment Post</h2>
-        <Box display="flex" alignItems="center" gap="8px">
-          <Button variant="text" type="reset" disabled={!isModified}>
-            Reset
-          </Button>
-          <Button variant="contained" color="primary" type="submit" disabled={!isModified}>
-            Save Changes
-          </Button>
-        </Box>
+        {authData.permissions.RECRUITMENT && (
+          <Box display="flex" alignItems="center" gap="8px">
+            <Button variant="text" type="reset" disabled={!isModified}>
+              Reset
+            </Button>
+            <Button variant="contained" color="primary" type="submit" disabled={!isModified}>
+              Save Changes
+            </Button>
+          </Box>
+        )}
       </Box>
       <div className="input-wrapper">
         <div className="buttons centered">
@@ -95,6 +99,7 @@ const RecruitmentPage: FC = () => {
         </div>
         <TextField
           value={title}
+          disabled={!authData.permissions.RECRUITMENT}
           required
           onChange={e => setTitle(e.target.value)}
           fullWidth
@@ -120,6 +125,7 @@ const RecruitmentPage: FC = () => {
           multiline
           label="Content"
           value={message}
+          disabled={!authData.permissions.RECRUITMENT}
           onChange={e => setMessage(e.target.value)}
           fullWidth
           InputProps={{

--- a/client/src/components/roster/guild-member-menu.tsx
+++ b/client/src/components/roster/guild-member-menu.tsx
@@ -8,6 +8,7 @@ import Divider from '@mui/material/Divider';
 import Menu from '@mui/material/Menu';
 import { type PopoverPosition } from '@mui/material/Popover';
 import { useCallback } from 'react';
+import { type PermissionsDTO } from 'server';
 import type MemberRecord from '../../lib/interfaces/member-record';
 import GuildMemberDetails from './guild-member-details';
 import GuildMemberMenuItem from './guild-member-menu-item';
@@ -15,8 +16,8 @@ import GuildMemberMenuItem from './guild-member-menu-item';
 interface Props {
   member: MemberRecord;
   menuAnchor: PopoverPosition | undefined;
-  isAdmin: boolean;
-  memberIsAdmin: boolean;
+  permissions: PermissionsDTO;
+  memberIsHigherRole: boolean;
   closeMenu: () => void;
   onKick: (member: MemberRecord) => void;
   onEdit: (member: MemberRecord) => void;
@@ -29,8 +30,8 @@ interface Props {
 const GuildMemberMenu = ({
   member,
   menuAnchor,
-  isAdmin,
-  memberIsAdmin,
+  permissions,
+  memberIsHigherRole,
   closeMenu,
   onKick,
   onEdit,
@@ -68,32 +69,32 @@ const GuildMemberMenu = ({
       <GuildMemberMenuItem
         Icon={Close}
         label="Kick"
-        disabled={!isAdmin || memberIsAdmin || !member.discordId}
+        disabled={!permissions.MEMBERS || memberIsHigherRole || !member.discordId}
         className="error"
         action={() => menuAction(onKick)}
       />
       <GuildMemberMenuItem
         Icon={List}
         label="Edit Roles"
-        disabled={!isAdmin || memberIsAdmin || !member.discordId}
+        disabled={!permissions.MEMBERS || memberIsHigherRole || !member.discordId}
         action={() => menuAction(onEdit)}
       />
       <GuildMemberMenuItem
         Icon={Edit}
         label="Edit Nickname"
-        disabled={!isAdmin || memberIsAdmin || !member.discordId}
+        disabled={!permissions.MEMBERS || memberIsHigherRole || !member.discordId}
         action={() => menuAction(onChangeNickname)}
       />
       <GuildMemberMenuItem
         Icon={Person}
         label="Associate"
-        disabled={!isAdmin || !member.memberId}
+        disabled={!permissions.MEMBERS || !member.memberId}
         action={() => menuAction(() => onAssociateMember(member))}
       />
       <Divider />
       <GuildMemberMenuItem
         Icon={Warning}
-        disabled={!isAdmin || !member.discordId}
+        disabled={!permissions.WARNINGS || !member.discordId}
         className="warning"
         action={() => menuAction(() => setWarningOpen(true))}
         label="Give Warning"

--- a/client/src/components/roster/log-entry-viewer.scss
+++ b/client/src/components/roster/log-entry-viewer.scss
@@ -17,6 +17,7 @@ div.log-entry-viewer {
         display: flex;
         flex-wrap: wrap;
         gap: 8px 32px;
+        margin-right: 40px;
 
         .field {
           display: flex;
@@ -26,7 +27,6 @@ div.log-entry-viewer {
       }
 
       .actions {
-        margin-left: 40px;
         display: flex;
         flex: 0;
       }

--- a/client/src/components/roster/roster-control.tsx
+++ b/client/src/components/roster/roster-control.tsx
@@ -13,6 +13,7 @@ import type React from 'react';
 import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { useAuth } from '../../lib/apis/auth-api';
 import './roster-control.scss';
 
 interface Props {
@@ -40,6 +41,8 @@ const RosterControl = ({
   const [searchParams, setSearchParams] = useSearchParams();
   const sortBy = searchParams.get('sortBy');
   const filterBy = searchParams.get('filterBy');
+
+  const { data: authData } = useAuth();
 
   const [anchorElement, setAnchorElement] = useState<(EventTarget & Element) | null>(null);
   const [sortOpen, setSortOpen] = useState(false);
@@ -113,7 +116,11 @@ const RosterControl = ({
           {!kickMode && (
             <Tooltip title={'Mass kick (up to 5 members)'}>
               <span>
-                <IconButton size="small" onClick={() => setKickMode(true)}>
+                <IconButton
+                  disabled={!authData?.permissions.MEMBERS}
+                  size="small"
+                  onClick={() => setKickMode(true)}
+                >
                   <DeleteForever />
                 </IconButton>
               </span>

--- a/client/src/components/roster/roster.tsx
+++ b/client/src/components/roster/roster.tsx
@@ -11,6 +11,7 @@ import KickModal from './kick-modal';
 import RoleEdit from './role-edit';
 import RosterControl from './roster-control';
 
+import { useDiscordBotRoles } from '../../lib/apis/discord-api';
 import { useRoster } from './use-roster';
 
 const Roster = () => {
@@ -20,6 +21,8 @@ const Roster = () => {
   const filterBy = searchParams.get('filterBy') ?? '';
   const { isLoading, isFetching, refetch, isError, discordRoles, rosterForDisplay, roster } =
     useRoster(sortBy, filterString, filterBy);
+
+  const { data: botRoles, isLoading: botRolesLoading } = useDiscordBotRoles();
 
   const [kickMode, setKickMode] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
@@ -44,7 +47,16 @@ const Roster = () => {
 
   if (isError) return <ErrorMessage>There was an error getting roster data.</ErrorMessage>;
 
-  if (isLoading || !roster || !rosterForDisplay || !discordRoles) return <LoaderPage />;
+  if (
+    isLoading ||
+    !roster ||
+    !rosterForDisplay ||
+    !discordRoles ||
+    !authInfo ||
+    botRolesLoading ||
+    !botRoles
+  )
+    return <LoaderPage />;
 
   const selectedRecord = roster.find(r => r.discordId === selectedRecordId);
 
@@ -76,9 +88,10 @@ const Roster = () => {
                       key={member.memberId ?? member.discordId}
                       member={member}
                       discordRoles={discordRoles}
+                      botRoles={botRoles}
                       onKick={onKick}
                       onEdit={openEdit}
-                      isAdmin={authInfo?.isAdmin ?? false}
+                      authInfo={authInfo}
                       selection={selection}
                       setSelection={setSelection}
                       kickMode={kickMode}

--- a/client/src/components/roster/warnings/warning-entry.tsx
+++ b/client/src/components/roster/warnings/warning-entry.tsx
@@ -6,17 +6,18 @@ import List from '@mui/icons-material/List';
 import Person from '@mui/icons-material/Person';
 import { Card, IconButton, Typography } from '@mui/material';
 import { useCallback, useState } from 'react';
-import { type WarningDTO, type WarningType, WarningTypeLabels } from 'server';
+import { type AuthInfo, type WarningDTO, type WarningType, WarningTypeLabels } from 'server';
 import { useDeleteWarningMutation, useUpdateWarningMutation } from '../../../lib/apis/warnings-api';
 import { useConfirm } from '../../common/confirm-dialog';
 import WarningForm from './warning-form';
 
 export interface WarningEntryProps {
   warning: WarningDTO;
+  authData: AuthInfo;
   getNameForDiscordId: (id: string) => string;
 }
 
-export const WarningEntry = ({ warning, getNameForDiscordId }: WarningEntryProps) => {
+export const WarningEntry = ({ warning, getNameForDiscordId, authData }: WarningEntryProps) => {
   const confirm = useConfirm();
 
   const deleteWarningMutation = useDeleteWarningMutation();
@@ -60,14 +61,16 @@ export const WarningEntry = ({ warning, getNameForDiscordId }: WarningEntryProps
               <Typography>{warning.reason}</Typography>
             </span>
           </div>
-          <div className="actions">
-            <IconButton onClick={() => setShowUpdate(true)} disabled={isPending}>
-              <Edit color="primary" />
-            </IconButton>
-            <IconButton onClick={() => handleDeleteWarning()}>
-              <Close color="error" />
-            </IconButton>
-          </div>
+          {authData.permissions.WARNINGS && (
+            <div className="actions">
+              <IconButton onClick={() => setShowUpdate(true)} disabled={isPending}>
+                <Edit color="primary" />
+              </IconButton>
+              <IconButton onClick={() => handleDeleteWarning()}>
+                <Close color="error" />
+              </IconButton>
+            </div>
+          )}
         </div>
         {warning.lastUpdatedBy && (
           <div>

--- a/client/src/components/roster/warnings/warnings-viewer.tsx
+++ b/client/src/components/roster/warnings/warnings-viewer.tsx
@@ -2,6 +2,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import { useCallback } from 'react';
+import { useAuth } from '../../../lib/apis/auth-api';
 import { useDiscordMembers } from '../../../lib/apis/discord-api';
 import type MemberRecord from '../../../lib/interfaces/member-record';
 import { ErrorMessage } from '../../common/error-message';
@@ -17,6 +18,7 @@ interface Props {
 
 const WarningsViewer = ({ isOpen, onClose, member }: Props) => {
   const { data: discordMembers, isLoading, isError } = useDiscordMembers();
+  const { data: authData, isLoading: authLoading, isError: authError } = useAuth();
 
   const getNameForDiscordId = useCallback(
     (givenToId: string) => {
@@ -30,9 +32,10 @@ const WarningsViewer = ({ isOpen, onClose, member }: Props) => {
 
   if (member.warnings.length === 0 && isOpen) onClose();
 
-  if (isError) return <ErrorMessage>There was an error getting roster data.</ErrorMessage>;
+  if (isError || authError)
+    return <ErrorMessage>There was an error getting roster data.</ErrorMessage>;
 
-  if (isLoading || !discordMembers) return <LoaderPage />;
+  if (isLoading || !discordMembers || authLoading || !authData) return <LoaderPage />;
 
   return (
     <Dialog open={isOpen} onClose={onClose} maxWidth={false}>
@@ -41,6 +44,7 @@ const WarningsViewer = ({ isOpen, onClose, member }: Props) => {
         {member.warnings.map(warning => (
           <WarningEntry
             warning={warning}
+            authData={authData}
             key={warning.id}
             getNameForDiscordId={getNameForDiscordId}
           />

--- a/client/src/components/roster/warnings/warnings-viewer.tsx
+++ b/client/src/components/roster/warnings/warnings-viewer.tsx
@@ -28,7 +28,7 @@ const WarningsViewer = ({ isOpen, onClose, member }: Props) => {
     [discordMembers]
   );
 
-  if (member.warnings.length === 0) onClose();
+  if (member.warnings.length === 0 && isOpen) onClose();
 
   if (isError) return <ErrorMessage>There was an error getting roster data.</ErrorMessage>;
 

--- a/client/src/lib/apis/auth-api.ts
+++ b/client/src/lib/apis/auth-api.ts
@@ -7,7 +7,6 @@ const api = createApi('auth');
 
 const authApi: IAuthController = {
   getAuthorization: () => api('authorization'),
-  getAdminRoles: () => api('admin_roles'),
   getEventRoles: () => api('event_roles')
 };
 
@@ -15,12 +14,6 @@ export const useAuth = () =>
   useQuery({
     queryKey: ['auth/authorization'],
     queryFn: authApi.getAuthorization
-  });
-
-export const useAdminRoles = () =>
-  useQuery<string[], AxiosError>({
-    queryKey: ['auth/admin_roles'],
-    queryFn: authApi.getAdminRoles
   });
 
 export const useEventRoles = () =>

--- a/client/src/lib/apis/discord-api.ts
+++ b/client/src/lib/apis/discord-api.ts
@@ -17,6 +17,7 @@ const discordApi: IDiscordController = {
   getMembers: () => api('members'),
   getLogs: () => api('log'),
   getLeavers: () => api('leavers'),
+  getBotRoles: () => api('bot-roles'),
   addRoleToMember: (memberId, roleId) =>
     api(`members/${memberId}/roles/${roleId}`, { method: 'PUT' }),
   removeRoleFromMember: (memberId, roleId) =>
@@ -36,6 +37,8 @@ export const useDiscordLog = () =>
   useQuery({ queryKey: ['discord/log'], queryFn: discordApi.getLogs });
 export const useDiscordLeavers = () =>
   useQuery({ queryKey: ['discord/leavers'], queryFn: discordApi.getLeavers });
+export const useDiscordBotRoles = () =>
+  useQuery({ queryKey: ['discord/bot-roles'], queryFn: discordApi.getBotRoles });
 
 export interface ChangeRoleDTO {
   memberId: string;

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -9,7 +9,11 @@ declare namespace NodeJS {
     DISCORD_CLIENT_ID: string;
     DISCORD_CLIENT_SECRET: string;
     DISCORD_AUTH_REDIRECT: string;
-    ADMIN_ROLES: string;
+    AUTH_ACCESS: string;
+    AUTH_MANAGE_EVENTS: string;
+    AUTH_MANAGE_WARNINGS: string;
+    AUTH_MANAGE_MEMBERS: string;
+    AUTH_MANAGE_RECRUITMENT: string;
     EVENT_ROLES: string;
     SESSION_SECRET: string;
     ACCESS_TOKEN_ENCRYPTION_KEY: string;

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -23,7 +23,11 @@ export const config = {
   discordClientId: process.env.DISCORD_CLIENT_ID,
   discordClientSecret: process.env.DISCORD_CLIENT_SECRET,
   discordAuthRedirect: process.env.DISCORD_AUTH_REDIRECT,
-  adminRoles: process.env.ADMIN_ROLES?.split(',') ?? [],
+  accessRoles: process.env.AUTH_ACCESS?.split(',') ?? [],
+  manageEventsRoles: process.env.AUTH_MANAGE_EVENTS?.split(',') ?? [],
+  manageMembersRoles: process.env.AUTH_MANAGE_MEMBERS?.split(',') ?? [],
+  manageWarningsRoles: process.env.AUTH_MANAGE_WARNINGS?.split(',') ?? [],
+  manageRecruitmentRoles: process.env.AUTH_MANAGE_RECRUITMENT?.split(',') ?? [],
   eventRoles: process.env.EVENT_ROLES?.split(',') ?? [],
   sessionSecret: process.env.SESSION_SECRET,
   frontEndBaseUrl:

--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -4,7 +4,6 @@ import {
   Authorized,
   CurrentUser,
   Get,
-  Header,
   JsonController,
   Redirect,
   Req,
@@ -55,21 +54,14 @@ export class AuthController implements IAuthController {
   }
 
   @Get('/authorization')
-  @Header('Cache-control', 'no-store')
   getAuthorization(@CurrentUser() user?: Express.User): Promise<AuthInfo> {
-    return this.authService.getUserAuthInfo(user);
-  }
-
-  @Get('/admin_roles')
-  @Authorized()
-  getAdminRoles(): Promise<string[]> {
-    return Promise.resolve(config.adminRoles);
+    return this.authService.getUserAuthInfo(user?.id);
   }
 
   @Get('/event_roles')
   @Authorized()
   getEventRoles(): Promise<string[]> {
-    return Promise.resolve(config.eventRoles.concat(config.adminRoles));
+    return Promise.resolve(config.eventRoles);
   }
 }
 

--- a/server/src/controllers/events-controller.ts
+++ b/server/src/controllers/events-controller.ts
@@ -65,6 +65,7 @@ export class EventsController implements IEventsController {
   }
 
   @Delete('/:id')
+  @Authorized('EVENTS')
   @OnUndefined(204)
   async delete(@Param('id') id: number): Promise<void> {
     const res = await this.eventRepo.delete(id);
@@ -75,11 +76,13 @@ export class EventsController implements IEventsController {
   }
 
   @Post('/')
+  @Authorized('EVENTS')
   create(@Body() event: EventCreateDTO): Promise<EventDTO> {
     return this.eventRepo.create(event);
   }
 
   @Put('/:id')
+  @Authorized('EVENTS')
   @OnNull(404)
   update(@Param('id') id: number, @Body() event: EventCreateDTO): Promise<EventDTO | null> {
     return this.eventRepo.update(id, event);

--- a/server/src/controllers/interfaces/auth-interface.ts
+++ b/server/src/controllers/interfaces/auth-interface.ts
@@ -2,6 +2,5 @@ import { AuthInfo } from '../../dtos';
 
 export interface IAuthController {
   getAuthorization(): Promise<AuthInfo>;
-  getAdminRoles(): Promise<string[]>;
   getEventRoles(): Promise<string[]>;
 }

--- a/server/src/controllers/interfaces/discord-interface.ts
+++ b/server/src/controllers/interfaces/discord-interface.ts
@@ -13,6 +13,7 @@ export interface IDiscordController {
   getMembers(): Promise<DiscordMemberDTO[]>;
   getLogs(): Promise<DiscordLog>;
   getLeavers(): Promise<MemberLeftDTO[]>;
+  getBotRoles(): Promise<DiscordRole[]>;
   addRoleToMember(memberId: string, roleId: string): Promise<void>;
   removeRoleFromMember(memberId: string, roleId: string): Promise<void>;
   updateMember(memberId: string, updates: DiscordMemberUpdate): Promise<void>;

--- a/server/src/controllers/recruitment-post-controller.ts
+++ b/server/src/controllers/recruitment-post-controller.ts
@@ -41,6 +41,7 @@ export class RecruitmentPostController implements IRecruitmentPostController {
   }
 
   @Put('/')
+  @Authorized('RECRUITMENT')
   async upsert(@Body() body: RecruitmentPostCreateDTO): Promise<RecruitmentPostDTO> {
     const post = await this.recruitmentRepo.getOne();
 
@@ -56,6 +57,7 @@ export class RecruitmentPostController implements IRecruitmentPostController {
 
   @Delete('/')
   @OnUndefined(204)
+  @Authorized('RECRUITMENT')
   async delete(): Promise<void> {
     const post = await this.recruitmentRepo.getOne();
 

--- a/server/src/controllers/warnings-controller.ts
+++ b/server/src/controllers/warnings-controller.ts
@@ -41,6 +41,7 @@ export class WarningsController implements IWarningsController {
 
   @Delete('/:id')
   @OnUndefined(204)
+  @Authorized('WARNINGS')
   async delete(@Param('id') id: number): Promise<void> {
     const res = await this.warningRepo.delete(id);
 
@@ -50,6 +51,7 @@ export class WarningsController implements IWarningsController {
   }
 
   @Post('/')
+  @Authorized('WARNINGS')
   create(
     @Body() warning: WarningCreateDTO,
     @CurrentUser() user?: Express.User
@@ -58,6 +60,7 @@ export class WarningsController implements IWarningsController {
   }
 
   @Put('/:id')
+  @Authorized('WARNINGS')
   @OnNull(404)
   update(
     @Param('id') id: number,

--- a/server/src/discord-bot/commands/events/create.ts
+++ b/server/src/discord-bot/commands/events/create.ts
@@ -4,7 +4,6 @@ import {
   ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
-  PermissionFlagsBits,
   SlashCommandBooleanOption,
   SlashCommandBuilder,
   SlashCommandNumberOption,
@@ -13,7 +12,7 @@ import {
 } from 'discord.js';
 import { Service } from 'typedi';
 import { config } from '../../../config';
-import { DayOfWeek, daysOfWeek } from '../../../dtos';
+import { DayOfWeek, daysOfWeek, Permission } from '../../../dtos';
 import { DiscordApiFactory } from '../../../services/discord/api-factory';
 import { EventEmbedCreator } from '../../../services/discord/event-embed-creator';
 import { IDiscordGuildApi } from '../../../services/discord/guild-api';
@@ -37,7 +36,6 @@ export default class EventsCreateCommand implements Command {
     return new SlashCommandBuilder()
       .setName(this.name)
       .setDescription('Create an event')
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
       .addStringOption(
         new SlashCommandStringOption()
           .setRequired(true)
@@ -99,10 +97,7 @@ export default class EventsCreateCommand implements Command {
     const title = interaction.options.getString('title', true);
 
     const member = await this.discordGuildApi.getMemberById(leader.id);
-    if (
-      !member ||
-      ![...config.eventRoles, ...config.adminRoles].some(r => member.roles.includes(r))
-    ) {
+    if (!member || ![...config.eventRoles].some(r => member.roles.includes(r))) {
       interaction.editReply(`<@${leader.id}> is not a valid event leader.`);
     }
 
@@ -158,5 +153,9 @@ export default class EventsCreateCommand implements Command {
     }
 
     await this.eventRepo.getAll();
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return ['EVENTS'];
   }
 }

--- a/server/src/discord-bot/commands/events/delete.ts
+++ b/server/src/discord-bot/commands/events/delete.ts
@@ -1,13 +1,12 @@
 import {
   ActionRowBuilder,
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
   SlashCommandBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder
 } from 'discord.js';
 import { Service } from 'typedi';
-import { daysOfWeek } from '../../../dtos';
+import { daysOfWeek, Permission } from '../../../dtos';
 import { DiscordApiFactory } from '../../../services/discord/api-factory';
 import { IDiscordGuildApi } from '../../../services/discord/guild-api';
 import { EventRepository } from '../../../services/repositories/event-repository';
@@ -28,10 +27,11 @@ export default class EventsDeleteCommand implements Command {
   }
 
   async getConfig() {
-    return new SlashCommandBuilder()
-      .setName(this.name)
-      .setDescription('Delete an event')
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+    return new SlashCommandBuilder().setName(this.name).setDescription('Delete an event');
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return ['EVENTS'];
   }
 
   async execute(interaction: ChatInputCommandInteraction) {

--- a/server/src/discord-bot/commands/events/list.ts
+++ b/server/src/discord-bot/commands/events/list.ts
@@ -1,11 +1,6 @@
-import {
-  ChatInputCommandInteraction,
-  EmbedBuilder,
-  PermissionFlagsBits,
-  SlashCommandBuilder
-} from 'discord.js';
+import { ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { Service } from 'typedi';
-import { daysOfWeek } from '../../../dtos';
+import { daysOfWeek, Permission } from '../../../dtos';
 import { EventEmbedCreator } from '../../../services/discord/event-embed-creator';
 import { EventRepository } from '../../../services/repositories/event-repository';
 import { Command } from '../../command-factory';
@@ -21,10 +16,11 @@ export default class EventsListCommand implements Command {
   }
 
   async getConfig() {
-    return new SlashCommandBuilder()
-      .setName(this.name)
-      .setDescription('List all events')
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+    return new SlashCommandBuilder().setName(this.name).setDescription('List all events');
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return [];
   }
 
   async execute(interaction: ChatInputCommandInteraction) {

--- a/server/src/discord-bot/commands/warnings/create.ts
+++ b/server/src/discord-bot/commands/warnings/create.ts
@@ -1,12 +1,11 @@
 import {
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
   SlashCommandBuilder,
   SlashCommandStringOption,
   SlashCommandUserOption
 } from 'discord.js';
 import { Service } from 'typedi';
-import { WarningType, WarningTypeLabels } from '../../../dtos';
+import { Permission, WarningType, WarningTypeLabels } from '../../../dtos';
 import WarningsRepository from '../../../services/repositories/warnings-repository';
 import { Command } from '../../command-factory';
 
@@ -42,8 +41,11 @@ export default class WarningsGiveCommand implements Command {
           .setName('reason')
           .setDescription('Reason for warning')
           .setRequired(true)
-      )
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+      );
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return ['WARNINGS'];
   }
 
   async execute(interaction: ChatInputCommandInteraction) {

--- a/server/src/discord-bot/commands/warnings/delete.ts
+++ b/server/src/discord-bot/commands/warnings/delete.ts
@@ -1,14 +1,13 @@
 import {
   ActionRowBuilder,
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
   SlashCommandBuilder,
   SlashCommandUserOption,
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder
 } from 'discord.js';
 import { Service } from 'typedi';
-import { WarningTypeLabels } from '../../../dtos';
+import { Permission, WarningTypeLabels } from '../../../dtos';
 import { DiscordApiFactory } from '../../../services/discord/api-factory';
 import { IDiscordGuildApi } from '../../../services/discord/guild-api';
 import WarningsRepository from '../../../services/repositories/warnings-repository';
@@ -32,12 +31,15 @@ export default class WarningsDeleteCommand implements Command {
     return new SlashCommandBuilder()
       .setName(this.name)
       .setDescription('Delete a warning')
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
       .addUserOption(
         new SlashCommandUserOption()
           .setName('given-to-user')
           .setDescription('Optionally filter options by user given to')
       );
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return ['WARNINGS'];
   }
 
   async execute(interaction: ChatInputCommandInteraction) {

--- a/server/src/discord-bot/commands/warnings/list.ts
+++ b/server/src/discord-bot/commands/warnings/list.ts
@@ -1,11 +1,10 @@
 import {
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
   SlashCommandBuilder,
   SlashCommandUserOption
 } from 'discord.js';
 import { Service } from 'typedi';
-import { WarningTypeLabels } from '../../../dtos';
+import { Permission, WarningTypeLabels } from '../../../dtos';
 import WarningsRepository from '../../../services/repositories/warnings-repository';
 import { Command } from '../../command-factory';
 
@@ -20,12 +19,15 @@ export default class WarningsListCommand implements Command {
     return new SlashCommandBuilder()
       .setName(this.name)
       .setDescription('List all warnings')
-      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
       .addUserOption(
         new SlashCommandUserOption()
           .setName('given-to-user')
           .setDescription('Filter by user given to')
       );
+  }
+
+  getRequiredPermissions(): Permission[] {
+    return [];
   }
 
   async execute(interaction: ChatInputCommandInteraction) {

--- a/server/src/dtos/auth/auth-info.ts
+++ b/server/src/dtos/auth/auth-info.ts
@@ -1,5 +1,8 @@
+import { PermissionsDTO } from './permissions-dto';
+
 export interface AuthInfo {
   loggedIn: boolean;
-  isAdmin: boolean;
   username: string;
+  roles: string[];
+  permissions: PermissionsDTO;
 }

--- a/server/src/dtos/auth/index.ts
+++ b/server/src/dtos/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './auth-info';
+export * from './permissions-dto';

--- a/server/src/dtos/auth/permissions-dto.ts
+++ b/server/src/dtos/auth/permissions-dto.ts
@@ -1,0 +1,9 @@
+export interface PermissionsDTO {
+  ACCESS: boolean;
+  EVENTS: boolean;
+  WARNINGS: boolean;
+  RECRUITMENT: boolean;
+  MEMBERS: boolean;
+}
+
+export type Permission = keyof PermissionsDTO;

--- a/server/src/dtos/discord/discord-member.ts
+++ b/server/src/dtos/discord/discord-member.ts
@@ -1,10 +1,12 @@
+export interface DiscordUser {
+  id: string;
+  username: string;
+  avatar?: string;
+  global_name?: string;
+}
+
 export interface DiscordMember {
-  user?: {
-    id: string;
-    username: string;
-    avatar?: string;
-    global_name?: string;
-  };
+  user?: DiscordUser;
   roles: string[];
   nick?: string;
   joined_at: string;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,6 +10,7 @@ import { init as initAxiosLogger } from './axios-logger';
 import { config } from './config';
 import { dataSource } from './dataSource';
 import { DiscordBot } from './discord-bot/discord-bot';
+import { Permission } from './dtos';
 import { AuthService } from './services/auth/auth-service';
 import { DiscordStrategySetup } from './services/auth/strategies/discord-strategy';
 import { EventUpdater } from './services/discord/event-updater';
@@ -46,7 +47,7 @@ app.use(passport.session());
 useExpressServer(app, {
   cors: true,
   controllers: [path.join(__dirname + '/controllers/*-controller.*')],
-  authorizationChecker: async (action: Action) => {
+  authorizationChecker: async (action: Action, roles: Permission[]) => {
     if (process.env.NODE_ENV === 'development' && config.skipAuth) {
       return true;
     }
@@ -55,8 +56,7 @@ useExpressServer(app, {
       return false;
     }
 
-    const info = await Container.get(AuthService).getUserAuthInfo(action.request.user);
-    return info.loggedIn && info.isAdmin;
+    return await Container.get(AuthService).checkPermissionsWithId(action.request.user.id, roles);
   },
   currentUserChecker: (action: Action) => action.request.user
 });

--- a/server/src/services/auth/auth-service.ts
+++ b/server/src/services/auth/auth-service.ts
@@ -1,50 +1,97 @@
 import cache from 'memory-cache';
 import Container, { Service } from 'typedi';
 import { config } from '../../config';
-import { AuthInfo, DiscordMember } from '../../dtos';
+import { AuthInfo, DiscordMember, Permission, PermissionsDTO } from '../../dtos';
 import { DiscordGuildApi } from '../discord/guild-api';
 
-const notLoggedIn = {
+const notLoggedIn: AuthInfo = {
   loggedIn: false,
-  isAdmin: false,
-  username: ''
+  username: '',
+  roles: [],
+  permissions: {
+    ACCESS: false,
+    EVENTS: false,
+    MEMBERS: false,
+    RECRUITMENT: false,
+    WARNINGS: false
+  }
 };
 
-const skipAuth = {
+const skipAuth: AuthInfo = {
   loggedIn: true,
-  isAdmin: true,
-  username: 'dev'
+  username: 'dev',
+  roles: config.accessRoles,
+  permissions: {
+    ACCESS: true,
+    EVENTS: true,
+    MEMBERS: true,
+    RECRUITMENT: true,
+    WARNINGS: true
+  }
 };
 
 @Service()
 export class AuthService {
   constructor() {}
 
-  async getUserAuthInfo(user?: Express.User): Promise<AuthInfo> {
+  async getUserAuthInfo(userId?: string): Promise<AuthInfo> {
     if (process.env.NODE_ENV === 'development' && config.skipAuth) {
       return skipAuth;
     }
 
-    if (!user) return notLoggedIn;
+    if (!userId) return notLoggedIn;
 
     const loggedIn = true;
-    const username = user.username;
-    let isAdmin = false;
 
+    const cacheKey = `discord-member/${config.discordGuildId}/${userId}`;
+    let cachedMember: Promise<DiscordMember | undefined> | null = cache.get(cacheKey);
     try {
-      const guildApi = Container.get(DiscordGuildApi);
-
-      const cacheKey = `discord-member/${config.discordGuildId}/${user.id}`;
-      let member: DiscordMember | undefined = cache.get(cacheKey);
-      if (!member) {
-        member = await guildApi.getMemberById(user.id);
-        if (member) cache.put(cacheKey, member, 5000);
+      if (!cachedMember) {
+        const guildApi = Container.get(DiscordGuildApi);
+        cachedMember = guildApi.getMemberById(userId);
+        cache.put(cacheKey, cachedMember, 10000);
       }
-      isAdmin = !!member && member.roles.some(r => config.adminRoles.includes(r));
     } catch (err) {
       console.error(err);
     }
 
-    return { loggedIn, isAdmin, username };
+    const member = await cachedMember;
+
+    const username = member?.user?.username;
+    const roles = member?.roles ?? [];
+
+    return {
+      loggedIn,
+      username: username ?? 'Unknown',
+      roles,
+      permissions: this.getPermissions(roles)
+    };
+  }
+
+  checkPermissions(user: AuthInfo, roles: Permission[] = []) {
+    const hasPermission =
+      user.permissions.ACCESS && roles.every(r => user.permissions[r as Permission]);
+
+    return user.loggedIn && hasPermission;
+  }
+
+  async checkPermissionsWithId(userId?: string, roles: Permission[] = []) {
+    const user = await this.getUserAuthInfo(userId);
+    return this.checkPermissions(user, roles);
+  }
+
+  getPermissions(userRoles: string[]): PermissionsDTO {
+    return {
+      ACCESS: this.hasRequiredRoles(config.accessRoles, userRoles),
+      EVENTS: this.hasRequiredRoles(config.eventRoles, userRoles),
+      MEMBERS: this.hasRequiredRoles(config.manageMembersRoles, userRoles),
+      RECRUITMENT: this.hasRequiredRoles(config.manageRecruitmentRoles, userRoles),
+      WARNINGS: this.hasRequiredRoles(config.manageWarningsRoles, userRoles)
+    };
+  }
+
+  private hasRequiredRoles(requiredRoles: string[], userRoles: string[]) {
+    if (requiredRoles.length === 0) return false;
+    return requiredRoles.some(r => userRoles.includes(r));
   }
 }

--- a/server/src/services/discord/api-factory.ts
+++ b/server/src/services/discord/api-factory.ts
@@ -4,6 +4,8 @@ import { DiscordChannelApi, IDiscordChannelApi } from './channel-api';
 import { DiscordGuildApi, IDiscordGuildApi } from './guild-api';
 import { MockDiscordChannelApi } from './mocks/channel-api-mock';
 import { MockDiscordGuildApi } from './mocks/guild-api-mock';
+import { MockDiscordUserApi } from './mocks/user-api-mock';
+import { DiscordUserApi, IDiscordUserApi } from './user-api';
 
 @Service()
 export class DiscordApiFactory {
@@ -13,6 +15,10 @@ export class DiscordApiFactory {
 
   guildApi(): IDiscordGuildApi {
     return this.isDev() ? Container.get(MockDiscordGuildApi) : Container.get(DiscordGuildApi);
+  }
+
+  userApi(): IDiscordUserApi {
+    return this.isDev() ? Container.get(MockDiscordUserApi) : Container.get(DiscordUserApi);
   }
 
   private isDev() {

--- a/server/src/services/discord/mocks/user-api-mock.ts
+++ b/server/src/services/discord/mocks/user-api-mock.ts
@@ -1,0 +1,13 @@
+import { Service } from 'typedi';
+import { DiscordUser } from '../../../dtos';
+import { IDiscordUserApi } from '../user-api';
+
+@Service()
+export class MockDiscordUserApi implements IDiscordUserApi {
+  async getCurrentUser(): Promise<DiscordUser> {
+    return {
+      id: '1',
+      username: 'Bot'
+    };
+  }
+}

--- a/server/src/services/discord/user-api.ts
+++ b/server/src/services/discord/user-api.ts
@@ -1,0 +1,16 @@
+import { Service } from 'typedi';
+import { DiscordUser } from '../../dtos';
+import { DiscordApi } from './discord-api';
+
+export interface IDiscordUserApi {
+  getCurrentUser(): Promise<DiscordUser>;
+}
+
+@Service()
+export class DiscordUserApi implements IDiscordUserApi {
+  constructor(private readonly discordApi: DiscordApi) {}
+
+  async getCurrentUser(): Promise<DiscordUser> {
+    return this.discordApi.get('users/@me');
+  }
+}


### PR DESCRIPTION
* can now set roles allowed to do the following (respectively) via env variables
  * ACCESS the app / bot commands - this generally covers read-only access to most features
  * manage EVENTS
  * manage MEMBERS
  * manager RECRUITMENT posts
  * manage WARNINGS
* TODO - would be good to move these to DB - but this will do for now

* bot commands are now authorised with the above logic
* controllers are now authorised with the above logic
* UI is updated to respect these permissions
  * also disables actions the bot doesn't have permission to do (i.e. kicking higher ranking people)
* also attempts to improve user auth info caching to prevent rate limiting